### PR TITLE
Added predefined repos handling

### DIFF
--- a/repos.txt
+++ b/repos.txt
@@ -1,0 +1,2 @@
+ekomysl https://github.com/os-myodoo/EKO-MYSL.git
+gratka https://github.com/os-myodoo/Grupa-Morizon-Gratka.git


### PR DESCRIPTION
Last line of repos.txt must be blank. Now you can use predefined repos by:

./docker_start.sh -n test_project -a test_repo

if you have test_repo in repos.txt, it will use URL assigned to that repo. Two examples provided in repos.txt file, adjust that file to your needs.